### PR TITLE
Fix typo in scripts/test-flow.sh

### DIFF
--- a/scripts/test-flow.sh
+++ b/scripts/test-flow.sh
@@ -64,7 +64,7 @@ if [ -z "${STORAGE_NAME}" ]; then
   echo "[X] - STORAGE_NAME is not set"
   OK=0
 else
-  echo "STORAGE_NAME is set to ${PROJECT_NAME}"
+  echo "STORAGE_NAME is set to ${STORAGE_NAME}"
 fi
 
 if [ $OK == 0 ]; then


### PR DESCRIPTION
This PR fixes a typo in the prerequisite checks section of `scripts/test-flow.sh`.

Previously, `STORAGE_NAME` was being incorrectly echoed to stdout as `PROJECT_NAME`.

xref #19 (to track related PRs)