### PR TITLE
Use `#!/usr/bin/env bash` in `get-info.sh` to support macOS users

### DIFF
--- a/scripts/get-info.sh
+++ b/scripts/get-info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function cleanupK8s {
   echo "Killing Kubernetes tunnel"

--- a/scripts/get-info.sh
+++ b/scripts/get-info.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+if [ "${BASH_VERSION::1}" -lt 4 ]; then
+  echo "This script uses the mapfile command which was added in bash version 4.0.0"
+  echo "The bash installed in your /usr/bin/env is version $BASH_VERSION"
+  echo "Please upgrade the bash version installed in /usr/bin/env to a version >= 4.0.0"
+  exit 1
+fi
+
 function cleanupK8s {
   echo "Killing Kubernetes tunnel"
   pkill -P $$


### PR DESCRIPTION
`get-info.sh` uses the `mapfile` command

https://github.com/pangeo-forge/pangeo-forge-gcs-bakery/blob/5ee52878f0f399c56e14c0500aa430d48b173154/scripts/get-info.sh#L23

This does not work out-of-the-box on macOS, because even the latest Macs (mine is about ~2 months old) ship with system bash as bash 3, but [`mapfile` was introduced in bash 4](https://github.com/jitterbit/get-changed-files/issues/15#issuecomment-724909010). 👈 This linked issue recommends upgrading bash with homebrew and then `sudo mv /usr/local/bin/bash /bin/bash`. This solution might work in a GitHub Workflows context, but on an actual MacBook, write access to `/bin` is blocked (even for root users) by security features which are cumbersome to circumvent.

For executing scripts with user-installed versions of bash, this [tutorial](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba) recommends the `#!/usr/bin/env bash` syntax added in this PR. I contemplated replacing `#!/bin/bash` with this in all of the scripts for consistency, but thought it would be better to only make the minimal required change.

I am going to add a check for bash version to this PR, so the code self-documents why we are doing this, and then I will open for review.

xref #19 (b/c this issue arose as part of that work) 

