### PR TITLE
Upgrade required providers (for Apple Silicon compatibility)

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "3.5.0"
+      version = "4.9.0"
     }
   }
 }


### PR DESCRIPTION
This is a better solution for the Apple Silicon compatibility problem identified in #28, which conforms to @tracetechnical's [guidance to version lock providers](https://github.com/pangeo-forge/pangeo-forge-gcs-bakery/issues/28#issuecomment-1024727334). It turns out that the earlier specified version just didn't have an Apple Silicon build available for it, but upgrading to this version `4.9.0` solves the problem.

xref #19 (because this is part of that effort)