### PR TITLE
Test recipe: fix `getLogger` and use `copy_pruned`

### DIFF
--- a/test/recipes/oisst_recipe.py
+++ b/test/recipes/oisst_recipe.py
@@ -21,7 +21,7 @@ def set_log_level(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         logging.basicConfig()
-        logging.getLogger("pangeo_forge.recipes.xarray_zarr").setLevel(
+        logging.getLogger("pangeo_forge_recipes").setLevel(
             level=logging.DEBUG
         )
         result = func(*args, **kwargs)
@@ -69,7 +69,7 @@ def register_recipe(recipe: BaseRecipe):
         """
     )
 
-    flow_name = "test-noaa-flow"
+    flow_name = "test-noaa-flow-pruned"
     flow.storage = GCS(
         bucket=f"{storage_name}"
     )
@@ -118,4 +118,5 @@ if __name__ == "__main__":
     pattern = pattern_from_file_sequence(input_urls, "time", nitems_per_file=1)
 
     recipe = XarrayZarrRecipe(pattern, inputs_per_chunk=20)
-    register_recipe(recipe)
+    pruned_recipe = recipe.copy_pruned()
+    register_recipe(pruned_recipe)


### PR DESCRIPTION
This PR does two things. The first is a fix, which is to get the logger named `"pangeo_forge_recipes"`, because: (a) there actually is no module and/or logger named `"pangeo_forge"` in the bakery image we are using; and (b) the previous approach which, IIUC, aims to log only for `pangeo_forge_recipes.recipes.xarray_zarr`, doesn't capture logging from other modules (e.g. `storage`) which are important for debugging.

The second thing this PR does is register a `copy_pruned` subset of the recipe object, rather than the full timeseries. This is perhaps a bit more opinionated of a choice. I'm making it because at this stage of testing, IMHO, we don't need to be moving a lot of data around, but rather just ensuring that we can get end-to-end on a single recipe execution cycle. (And this is what the `copy_pruned` method was designed for: to provide a smaller subset of the recipe for workflow debugging.)

xref https://github.com/pangeo-forge/pangeo-forge-gcs-bakery/issues/19#issuecomment-1028977632